### PR TITLE
Upgrade to video.js 4.0

### DIFF
--- a/example.html
+++ b/example.html
@@ -2,9 +2,9 @@
 <html>
 <head>
   <title>Error Plugin Example</title>
-  <link href="lib/video-js/video-js.css" rel="stylesheet">
+  <link href="http://vjs.zencdn.net/4.0/video-js.css" rel="stylesheet">
+  <script src="http://vjs.zencdn.net/4.0/video.js"></script>
   <link href="videojs.errors.css" rel="stylesheet">
-  <script src="lib/video-js/video.js"></script>
 </head>
 <body>
 <video id="video" class="video-js vjs-default-skin" controls


### PR DESCRIPTION
Use the official video.js 4.0 URL from zencoder in the example page.
