### PR TITLE
Ended videos should not cause player timeouts on IE11 / Win8 RT

### DIFF
--- a/src/videojs.errors.js
+++ b/src/videojs.errors.js
@@ -54,6 +54,11 @@
         resetMonitor = function() {
           window.clearTimeout(monitor);
           monitor = window.setTimeout(function() {
+            if (player.error()) {
+              // never overwrite existing errors
+              return;
+            }
+
             player.error({
               code: -2,
               type: 'PLAYER_ERR_TIMEOUT'
@@ -73,6 +78,10 @@
             // playback isn't expected if the player is paused, shut
             // down monitoring
             if (player.paused()) {
+              return cleanup();
+            }
+            // playback isn't expected once the video has ended
+            if (player.ended()) {
               return cleanup();
             }
             fn.call(this);

--- a/test/videojs-errors.test.js
+++ b/test/videojs-errors.test.js
@@ -244,6 +244,37 @@
     ok(!player.error(), 'no error fired');
   });
 
+  // video.paused is false at the end of a video on IE11, Win8 RT
+  test('player timeouts do not occur if the video is ended', function() {
+    player.src({
+      src: 'http://example.com/movie.mp4',
+      type: 'video/mp4'
+    });
+    player.trigger('play');
+    // simulate a misbehaving player that doesn't fire `ended`
+    player.ended = function() {
+      return true;
+    };
+    clock.tick(45 * 1000);
+
+    ok(!player.error(), 'no error fired');
+  });
+
+  test('player timeouts do not overwrite existing errors', function() {
+    player.src({
+      src: 'http://example.com/movie.mp4',
+      type: 'video/mp4'
+    });
+    player.trigger('play');
+    player.error({
+      type: 'custom',
+      code: -7
+    });
+    clock.tick(45 * 1000);
+
+    strictEqual(-7, player.error().code, 'error was not overwritten');
+  });
+
   test('unrecognized error codes do not cause exceptions', function() {
     var errors = 0;
     player.on('error', function() {


### PR DESCRIPTION
video.paused is not true at the end of a video on Surface tablets. Check video.ended as well, which does seem to report correctly.
