### PR TITLE
feat: Add timeout getter/setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A plugin that displays user-friendly messages when Video.js encounters an error.
   - [Custom Errors](#custom-errors)
   - [Custom Errors without a Type](#custom-errors-without-a-type)
   - [`getAll()`](#getall)
+  - [`timeout()`](#timeout)
 - [Known Issues](#known-issues)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -144,6 +145,14 @@ var errors = player.errors.getAll();
 
 console.log(errors['1'].type); // "MEDIA_ERR_ABORTED"
 ```
+
+### `timeout()`
+
+After the errors plugin has been initialized on a player, a `timeout()` method is available on the `errors()` plugin method.
+
+A new timeout may be set by passing a timeout in milliseconds, e.g. `player.errors.timeout(5 * 1000)`.
+
+If no argument is passed, the current timeout value is returned. 
 
 ## Known Issues
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -295,6 +295,19 @@ const initPlugin = function(player, options) {
   reInitPlugin.extend = (errors) => updateErrors(errors);
   reInitPlugin.getAll = () => videojs.mergeOptions(options.errors);
 
+  // Get / set timeout value. Restart monitor if changed.
+  reInitPlugin.timeout = function(timeout) {
+    if (typeof timeout === 'undefined') {
+      return options.timeout;
+    }
+    if (timeout !== options.timeout) {
+      options.timeout = timeout;
+      if (!player.paused()) {
+        onPlayStartMonitor();
+      }
+    }
+  };
+
   reInitPlugin.disableProgress = function(disabled) {
     options.progressDisabled = disabled;
     onPlayStartMonitor();

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -255,6 +255,33 @@ QUnit.test('reinitialising plugin during playback starts timeout handler', funct
   assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
 });
 
+QUnit.test('timeout can be got and set', function(assert) {
+  assert.strictEqual(this.player.errors.timeout(), 45 * 1000, 'default timeout reported');
+
+  this.player.errors.timeout(1 * 1000);
+
+  assert.strictEqual(this.player.errors.timeout(), 1 * 1000, 'timeout was updated');
+});
+
+QUnit.test('updating timeout during playback restarts timeout monitor', function(assert) {
+  let errors = 0;
+
+  this.player.on('error', function() {
+    errors++;
+  });
+  this.player.src(sources);
+  this.player.trigger('play');
+
+  // reinitialise while playing
+  this.player.errors.timeout(1000);
+
+  this.clock.tick(1 * 1000);
+
+  assert.strictEqual(errors, 1, 'emitted an error');
+  assert.strictEqual(this.player.error().code, -2, 'error code is -2');
+  assert.strictEqual(this.player.error().type, 'PLAYER_ERR_TIMEOUT');
+});
+
 // safari 7 on OSX can emit stalls when playback is just fine
 QUnit.test('stalling by itself is not an error', function(assert) {
   this.player.src(sources);


### PR DESCRIPTION
## Description
Related to #113, re-initialising the plugin just to change the timeout is somewhat overkill and risks inadvertently overwriting existing settings. 

## Specific Changes proposed
Added a getter / setter for the timeout value, also restarting the timeout if changes when playing.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
