### PR TITLE
feat: Remove vjs-errors-dialog id

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -254,7 +254,6 @@ const initPlugin = function(player, options) {
     const display = player.getChild('errorDisplay');
 
     content.className = 'vjs-errors-dialog';
-    content.id = 'vjs-errors-dialog';
 
     const errorCode = `<div class="vjs-errors-code"><b>${this.localize('Error Code')}:</b> ${(error.type || error.code)}</div>`;
     const isTimeoutError = error.code === -2;


### PR DESCRIPTION
## Description
It is currently possible for multiple errors to generate div elements with duplicate `vjs-errors-dialog` ids.

## Specific Changes proposed
Remove code to set `vjs-errors-dialog` on the generated div that wraps error content. The same string is already used to set a class on that element and the `vjs-errors-dialog` _id_ is not used for targeting in the plugin or the videojs org.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
