### PR TITLE
fix: prevent lint-staged git add warning and mergeOptions warning on Video.js@8

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,14 +88,8 @@
     "videojs-standard": "^9.0.1"
   },
   "lint-staged": {
-    "*.js": [
-      "vjsstandard --fix",
-      "git add"
-    ],
-    "README.md": [
-      "npm run docs:toc",
-      "git add"
-    ]
+    "*.js": "vjsstandard --fix",
+    "README.md": "npm run docs:toc"
   },
   "husky": {
     "hooks": {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,6 +2,8 @@ import videojs from 'video.js';
 import document from 'global/document';
 import {version as VERSION} from '../package.json';
 
+const merge = (videojs.obj && videojs.obj.merge) || videojs.merge;
+
 const FlashObj = videojs.getComponent('Flash');
 const defaultDismiss = !videojs.browser.IS_IPHONE;
 
@@ -73,7 +75,7 @@ const initPlugin = function(player, options) {
   const listeners = [];
 
   const updateErrors = function(updates) {
-    options.errors = videojs.mergeOptions(options.errors, updates);
+    options.errors = merge(options.errors, updates);
 
     // Create `code`s from errors which don't have them (based on their keys).
     Object.keys(options.errors).forEach(k => {


### PR DESCRIPTION
## Description
Prevents the following warning: 
`VIDEOJS: WARN: videojs.mergeOptions is deprecated and will be removed in 9.0; please use videojs.obj.merge instead.`

Also prevents a warning from lint-staged regarding `git add` (which was introduced in lint-staged v10)
`⚠ Some of your tasks use 'git add' command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.`

I can move the second change into another pull request if we want.